### PR TITLE
Fix start-stop-status script

### DIFF
--- a/scripts/start-stop-status
+++ b/scripts/start-stop-status
@@ -1,12 +1,13 @@
 #!/bin/bash
 case "$1" in
     start)
-	synosystemctl start pkguser-homebridge
+	synosystemctl start pkgctl-homebridge
         ;;
     stop)
-	synosystemctl stop pkguser-homebridge
+	synosystemctl stop pkgctl-homebridge
         ;;
     status)
+	synosystemctl get-active-status pkgctl-homebridge
         ;;
     log)
         echo ""


### PR DESCRIPTION
Use `pkgctl-homebridge` instead of `pkguser-homebridge` and implement the status command using `synosystemctl get-active-status`.

Before:
```
# /var/packages/homebridge/scripts/start-stop-status stop
Fail to stop [pkguser-homebridge].
```

After:
```
# /var/packages/homebridge/scripts/start-stop-status stop
[pkgctl-homebridge] stopped.
```